### PR TITLE
Fix environment crash

### DIFF
--- a/BaseProject.xcodeproj/project.pbxproj
+++ b/BaseProject.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.development;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "-D DEVELOPMENT";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Development;
@@ -564,6 +565,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.alpha;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "-D ALPHA";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Alpha;
@@ -656,6 +658,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.beta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "-D BETA";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Beta;
@@ -747,6 +750,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.production;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "-D PRODUCTION";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Production;

--- a/BaseProject.xcodeproj/xcshareddata/xcschemes/BaseProject.xcscheme
+++ b/BaseProject.xcodeproj/xcshareddata/xcschemes/BaseProject.xcscheme
@@ -89,13 +89,6 @@
             ReferencedContainer = "container:BaseProject.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "ENVIRONMENT"
-            value = "${CONFIGURATION}"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/BaseProject/Environment.swift
+++ b/BaseProject/Environment.swift
@@ -8,13 +8,16 @@
 
 import Foundation
 
-enum Environment {
+internal enum Environment {
     
     case development
     case alpha
     case beta
     case production
-    case test
+    
+}
+
+internal extension Environment {
     
     static var current: Environment {
         #if DEVELOPMENT
@@ -30,15 +33,33 @@ enum Environment {
             return .production
         #endif
     }
+
+}
+
+internal extension Environment {
+    
+    private static let EnvironmentKey = "ENVIRONMENT"
+    
+    // This property should be set in scheme Test action's arguments (environment variables).
+    private static let EnvironmentTest = "Test"
+    
+    // This property should be set in UITests by launchEnvironment arguments.
+    private static let EnvironmentUITest = "UITest"
     
     static var isTestTarget: Bool {
-        if case .test = Environment.current {
-            return true
-        } else {
-            return false
-        }
+        let environment = ProcessInfo.processInfo.environment
+        return environment[Environment.EnvironmentKey] == Environment.EnvironmentTest
     }
     
+    static var isUITestTarget: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment[Environment.EnvironmentKey] == Environment.EnvironmentUITest
+    }
+    
+}
+
+internal extension Environment {
+
     static var isRunningOnSimulator: Bool {
         #if (arch(i386) || arch(x86_64)) && os(iOS)
             return true

--- a/BaseProject/Environment.swift
+++ b/BaseProject/Environment.swift
@@ -17,20 +17,18 @@ enum Environment {
     case test
     
     static var current: Environment {
-        let environment = ProcessInfo.processInfo.environment["ENVIRONMENT"]!.lowercased()
-        if environment == "development" {
+        #if DEVELOPMENT
             return .development
-        } else if environment == "alpha" {
+        #endif
+        #if ALPHA
             return .alpha
-        } else if environment == "beta" {
+        #endif
+        #if BETA
             return .beta
-        } else if environment == "production" {
+        #endif
+        #if PRODUCTION
             return .production
-        } else if environment == "test" {
-            return .test
-        } else {
-            fatalError("Environment variable ENVIRONMENT isn't set.")
-        }
+        #endif
     }
     
     static var isTestTarget: Bool {

--- a/BaseProjectUITests/BaseProjectUITests.swift
+++ b/BaseProjectUITests/BaseProjectUITests.swift
@@ -19,7 +19,7 @@ class BaseProjectUITests: XCTestCase {
         continueAfterFailure = false
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         let application = XCUIApplication()
-        application.launchEnvironment = ["ENVIRONMENT": "Test"]
+        application.launchEnvironment = ["ENVIRONMENT": "UITest"]
         application.launch()
 
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.


### PR DESCRIPTION
## Summary ##

Fix: https://github.com/Wolox/ios-base-project/issues/8

- Setting environment using compiler flags instead of using environment variables, since they are not injected when the application is not executed from xcode.

- Adding `isUITestTarget` in `Environment`.
