### PR TITLE
workaround for apparent apple bug when testing. Testing with Iphone SE

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -229,6 +229,8 @@ reflected in `Info.plist` during building."
     desc "Run scan with default project and scheme"
     scan(
       configuration: build_configurations[:test],
+      # Because of a supposed Apple bug, CI builds fail if it doesn't run in iPhoneSE: travis-ci/travis-ci#6422
+      devices: ['iPhone SE'],
       clean: false
     )
 


### PR DESCRIPTION
## Summary ##

Fixing tests. It appears to be an Apple bug:

https://github.com/travis-ci/travis-ci/issues/6422

The current fix is to run the tests in the Iphone SE simulator.
