### PR TITLE
Fix checkBumpType bug regarding a first deploy

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,18 +108,6 @@ reflected in `Info.plist` during building."
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
-    desc "Back up version number from `Info.plist`."
-    info_plist_backup_version_number = get_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
-      key: 'CFBundleShortVersionString'
-    )
-
-    desc "Back up build number from `Info.plist`."
-    info_plist_backup_build_number = get_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
-      key: 'CFBundleVersion'
-    )
-
     desc "Read current version number from `TestFlight`."
     current_version_version = latest_testflight_version(
       bundle_id: bundle_identifier
@@ -142,6 +130,18 @@ reflected in `Info.plist` during building."
     ).to_s
 
     UI.message "Will release app increasing bump type: `%s`" % bump_type
+
+    desc "Back up version number from `Info.plist`."
+    info_plist_backup_version_number = get_info_plist_value(
+      path: project_plist_path % ENV['PROJECT_NAME'],
+      key: 'CFBundleShortVersionString'
+    )
+
+    desc "Back up build number from `Info.plist`."
+    info_plist_backup_build_number = get_info_plist_value(
+      path: project_plist_path % ENV['PROJECT_NAME'],
+      key: 'CFBundleVersion'
+    )
 
     desc "Define next build number depending on bump_type."
     next_build_number = (bump_type == "build" ? current_build_version.to_i : first_build) + 1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,7 +121,9 @@ reflected in `Info.plist` during building."
     )
 
     desc "Read current version number from `TestFlight`."
-    current_version_version = latest_testflight_version(bundle_id: bundle_identifier)
+    current_version_version = latest_testflight_version(
+      bundle_id: bundle_identifier
+    )
     if current_version_version.nil?
       current_version_version = Actions::CheckBumpTypeAction::FIRST_VERSION
     end

--- a/fastlane/actions/check_bump_type.rb
+++ b/fastlane/actions/check_bump_type.rb
@@ -19,6 +19,11 @@ module Fastlane
         is_first_deploy = params[:version] == FIRST_VERSION
         allowed_bump_types = BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[params[:build_configuration]]
 
+        # It is enforced in `Fastfile`.
+        if is_first_deploy
+          return allowed_bump_types.last
+        end
+
         if allowed_bump_types.count == 1
           return allowed_bump_types.first # The only allowed bump type possible
         end

--- a/fastlane/actions/check_bump_type.rb
+++ b/fastlane/actions/check_bump_type.rb
@@ -6,6 +6,7 @@ module Fastlane
       # If there's only one bump_type allowed it will use that one
       # If there isn't a bump_type specified and there are many allowed bump_types, it will ask the user
 
+      # Take care if any of these values needs to be changed. It may break the algoritmh!
       FIRST_VERSION = "0.0.0".freeze
       ALL_BUMP_TYPES = %i(build patch minor major).freeze
       BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES = {
@@ -19,15 +20,18 @@ module Fastlane
         is_first_deploy = params[:version] == FIRST_VERSION
         allowed_bump_types = BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[params[:build_configuration]]
 
+        # First deploy needs to be done as major. 
         # It is enforced in `Fastfile`.
         if is_first_deploy
           return allowed_bump_types.last
         end
 
+        # If there is only one allowed bump type, no need to ask the user.
         if allowed_bump_types.count == 1
-          return allowed_bump_types.first # The only allowed bump type possible
+          return allowed_bump_types.first
         end
 
+        # As long as the user chooses a non allowed bump type, ask again until a valid one is provided.
         bump_type = params[:bump_type]
         while not allowed_bump_types.include? bump_type do
           bump_type = UI.input "Choose the `bump_type` representing the type of deploy. It can be any of %s" % allowed_bump_types.to_s

--- a/fastlane/actions/check_bump_type.rb
+++ b/fastlane/actions/check_bump_type.rb
@@ -38,15 +38,6 @@ module Fastlane
           bump_type = bump_type.to_sym
         end
 
-        if is_first_deploy && bump_type != :major
-          UI.important "This seems to be your first deploy. It must be done as `%s`." % :major
-          if (UI.input "Do you want to make it as `%s`? y/N" % :major) == "y"
-            bump_type = :major
-          else
-            UI.user_error! "The first depoy must be done as %s. Please try again later." % :major
-          end
-        end
-
         bump_type
       end
 

--- a/fastlane/actions/check_bump_type.rb
+++ b/fastlane/actions/check_bump_type.rb
@@ -23,7 +23,7 @@ module Fastlane
         # First deploy needs to be done as major. 
         # It is enforced in `Fastfile`.
         if is_first_deploy
-          return allowed_bump_types.last
+          return :major
         end
 
         # If there is only one allowed bump type, no need to ask the user.

--- a/fastlane/actions/check_bump_type.rb
+++ b/fastlane/actions/check_bump_type.rb
@@ -19,10 +19,6 @@ module Fastlane
         is_first_deploy = params[:version] == FIRST_VERSION
         allowed_bump_types = BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[params[:build_configuration]]
 
-        if is_first_deploy
-          return :major
-        end
-
         if allowed_bump_types.count == 1
           return allowed_bump_types.first # The only allowed bump type possible
         end
@@ -30,12 +26,13 @@ module Fastlane
         bump_type = params[:bump_type]
         while not allowed_bump_types.include? bump_type do
           bump_type = UI.input "Choose the `bump_type` representing the type of deploy. It can be any of %s" % allowed_bump_types.to_s
+          bump_type = bump_type.to_sym
         end
 
-        if bump_type != :major
+        if is_first_deploy && bump_type != :major
           UI.important "This seems to be your first deploy. It must be done as `%s`." % :major
           if (UI.input "Do you want to make it as `%s`? y/N" % :major) == "y"
-            bump_type = allowed_bump_types.last
+            bump_type = :major
           else
             UI.user_error! "The first depoy must be done as %s. Please try again later." % :major
           end

--- a/fastlane/actions/latest_testflight_version.rb
+++ b/fastlane/actions/latest_testflight_version.rb
@@ -7,6 +7,9 @@ module Fastlane
       def self.run(params)
         Spaceship::Tunes.login
         app = Spaceship::Tunes::Application.find(params[:bundle_id])
+        if app.nil?
+          UI.abort_with_message! "The application is not yet created in iTunes Connect."
+        end
         app.all_build_train_numbers.max
       end
 


### PR DESCRIPTION
## Summary ##

This PR fixes a bug where it wouldn't ask for a major bumpType if it was first release, and would ask to be first release every time.