### PR TITLE
Backup versions use default instead of previous value

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,7 +178,7 @@ reflected in `Info.plist` during building."
       UI.message "Uploading version `%s` build `%s`" % [current_version_version, next_build_number]
       publish_testflight
     ensure
-      desc "Put back the backed up version number and build number in `Info.plist`."
+      desc "Put back the default version number and build number in `Info.plist`."
       set_info_plist_version(
         version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
         build_number: Actions::CheckBumpTypeAction::FIRST_BUILD

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,18 +131,6 @@ reflected in `Info.plist` during building."
 
     UI.message "Will release app increasing bump type: `%s`" % bump_type
 
-    desc "Back up version number from `Info.plist`."
-    info_plist_backup_version_number = get_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
-      key: 'CFBundleShortVersionString'
-    )
-
-    desc "Back up build number from `Info.plist`."
-    info_plist_backup_build_number = get_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
-      key: 'CFBundleVersion'
-    )
-
     desc "Define next build number depending on bump_type."
     current_build_number = bump_type == "build" ? current_build_version : Actions::CheckBumpTypeAction::FIRST_BUILD
     next_build_number = current_build_number + 1
@@ -192,8 +180,8 @@ reflected in `Info.plist` during building."
     ensure
       desc "Put back the backed up version number and build number in `Info.plist`."
       set_info_plist_version(
-        version_number: info_plist_backup_version_number,
-        build_number: info_plist_backup_build_number
+        version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
+        build_number: Actions::CheckBumpTypeAction::FIRST_BUILD
       )
     end
   end


### PR DESCRIPTION
## Summary ##

Use default version and build number instead of previous backed up version.
This makes the script lighter and less complex.
