### PR TITLE
Validate the xcconfig provided file exists. Otherwise returns nil instead of crashing.

### DIFF
--- a/fastlane/actions/read_xcconfig_property.rb
+++ b/fastlane/actions/read_xcconfig_property.rb
@@ -9,6 +9,9 @@ module Fastlane
       # is needed to be accessed from a fastlane script.
 
       def self.run(params)
+        if !File.exist?(params[:xcconfig_path])
+          return nil
+        end
         line = File.open(params[:xcconfig_path])
           .find { |each| each.start_with? params[:xcconfig_key] }
         line.to_s.empty? ? nil : line.split('=').last.strip


### PR DESCRIPTION
## Summary ##

If there is no `xcconfig` file matching the expected just returns nil.

It was crashing in react native projects which don't use `xcconfig` files. 