### PR TITLE
Infer the project name from the project

### DIFF
--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,8 +1,0 @@
-# Your project name
-PROJECT_NAME="BaseProject"
-
-# Developer Portal Team ID. (ex: "RDFGA2FGMD")
-TEAM_ID="7XS5GQGS29"
-
-# Brach in signing repository corresponding with TEAM_ID
-TEAM_BRANCH="wolox-team"

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -2,7 +2,5 @@
 apple_id "ios-si@wolox.com.ar"
 
 # Developer Portal Team ID. (ex: "RDFGA2FGMD")
+# Don't forget to change this in Matchfile also.
 team_id "7XS5GQGS29"
-
-# you can even provide different app identifiers, Apple IDs and team names per lane:
-# More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,7 +1,8 @@
-app_identifier "" # The bundle identifier of your app. (ex: "com.Wolox.Wolox")
-apple_id "ios-si@wolox.com.ar" # Your Apple email address. (ex: "yourName@wolox.com.ar")
+# Your Apple email address. (ex: "yourName@wolox.com.ar")
+apple_id "ios-si@wolox.com.ar"
 
-team_id ""  # Developer Portal Team ID. (ex: "RDFGA2FGMD")
+# Developer Portal Team ID. (ex: "RDFGA2FGMD")
+team_id "7XS5GQGS29"
 
 # you can even provide different app identifiers, Apple IDs and team names per lane:
 # More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -308,6 +308,13 @@ reflected in `Info.plist` during building."
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
+    UI.message "Attempting to create application for build configuration '#{options[:build_configuration]}'."
+    UI.message "Using name: '#{options[:app_name]}' and bundle ID: '#{bundle_identifier}'"
+    confirmation = UI.input "If the parameters are correct, proceed: Y/n"
+    unless confirmation.empty? || confirmation.downcase == "y"
+      UI.user_error! "Aborting due to parameters misconfiguration. Correct them and run the lane again."
+    end
+
     desc "Create App ID in developer center"
     produce(
       app_name: options[:app_name],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -229,7 +229,6 @@ reflected in `Info.plist` during building."
     create_app(
       app_name: app_names[:test] % project_name,
       build_configuration: build_configurations[:test],
-      team_name: ENV['TEAM_NAME'],
       skip_itc: true,
       match_type: match_types[:test],
     )
@@ -238,7 +237,6 @@ reflected in `Info.plist` during building."
     create_app(
       app_name: app_names[:qa] % project_name,
       build_configuration: build_configurations[:qa],
-      team_name: ENV['TEAM_NAME'],
       skip_itc: false,
       match_type: match_types[:qa],
     )
@@ -252,7 +250,6 @@ reflected in `Info.plist` during building."
     create_app(
       app_name: app_names[:appstore] % project_name,
       build_configuration: build_configurations[:appstore],
-      team_name: ENV['TEAM_NAME'],
       skip_itc: false,
       match_type: match_types[:appstore],
     )
@@ -315,7 +312,6 @@ reflected in `Info.plist` during building."
     produce(
       app_name: options[:app_name],
       app_identifier: bundle_identifier,
-      team_name: options[:team_name],
       skip_itc: options[:skip_itc]
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,12 +36,8 @@ platform :ios do
   # Run this before doing anything else
   before_all do
 
-    # Uncomment this if you don't have the carthage frameworks installed.
-    # carthage(
-    #   platform: "iOS",
-    #   use_binaries: false,
-    #   use_ssh: true
-    # )
+    desc "Simply validate the project name and main target are properly configured."
+    UI.message "Running lane for project: `%s`" % project_name
 
   end
 
@@ -151,13 +147,12 @@ reflected in `Info.plist` during building."
       build_app(
         app_identifier: bundle_identifier,
         configuration: build_configurations[build_configuration],
-        match_type: match_types[build_configuration],
-        project_name: ENV["PROJECT_NAME"]
+        match_type: match_types[build_configuration]
       )
 
       desc "Get rollbar server access token from configuration file."
       rollbar_server_access_token = read_xcconfig_property(
-        xcconfig_path: project_xcconfig_path % [ENV['PROJECT_NAME'], build_configurations[build_configuration]],
+        xcconfig_path: project_xcconfig_path % [project_name, build_configurations[build_configuration]],
         xcconfig_key: 'ROLLBAR_SERVER_ACCESS_TOKEN'
       )
 
@@ -169,7 +164,7 @@ reflected in `Info.plist` during building."
           access_token: rollbar_server_access_token,
           version: String(next_build_number),
           bundle_identifier: bundle_identifier,
-          dsym_zip_path: dsym_zip_path % ENV['PROJECT_NAME']
+          dsym_zip_path: dsym_zip_path % project_name
         )
 
       end
@@ -201,14 +196,14 @@ reflected in `Info.plist` during building."
 
     desc "Set version number in `Info.plist`."
     set_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
+      path: project_plist_path % project_name,
       key: 'CFBundleShortVersionString',
       value: version_number.to_s
     )
 
     desc "Set build number in `Info.plist`."
     set_info_plist_value(
-      path: project_plist_path % ENV['PROJECT_NAME'],
+      path: project_plist_path % project_name,
       key: 'CFBundleVersion',
       value: build_number.to_s
     )
@@ -232,7 +227,7 @@ reflected in `Info.plist` during building."
 
     desc "Remember after this point to choose this profile in xCode Signing (Development)"
     create_app(
-      app_name: app_names[:test] % ENV['PROJECT_NAME'],
+      app_name: app_names[:test] % project_name,
       build_configuration: build_configurations[:test],
       team_name: ENV['TEAM_NAME'],
       skip_itc: true,
@@ -241,7 +236,7 @@ reflected in `Info.plist` during building."
 
     desc "Remember after this point to choose this profile in xCode Signing (Alpha)"
     create_app(
-      app_name: app_names[:qa] % ENV['PROJECT_NAME'],
+      app_name: app_names[:qa] % project_name,
       build_configuration: build_configurations[:qa],
       team_name: ENV['TEAM_NAME'],
       skip_itc: false,
@@ -255,7 +250,7 @@ reflected in `Info.plist` during building."
     
     desc "Remember after this point to choose this profile in xCode Signing (Beta)"
     create_app(
-      app_name: app_names[:appstore] % ENV['PROJECT_NAME'],
+      app_name: app_names[:appstore] % project_name,
       build_configuration: build_configurations[:appstore],
       team_name: ENV['TEAM_NAME'],
       skip_itc: false,

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -5,7 +5,7 @@ username "ios-si@wolox.com.ar"
 git_url "git@github.com:Wolox/apple-certificates.git"
 
 # Branch in repository to take the signing information
-git_branch ENV["TEAM_BRANCH"]
+git_branch "wolox-team"
 
 # Team ID for signing
-team_id ENV["TEAM_ID"]
+team_id "7XS5GQGS29"

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -8,4 +8,5 @@ git_url "git@github.com:Wolox/apple-certificates.git"
 git_branch "wolox-team"
 
 # Team ID for signing
+# Don't forget to change this in Appfile also.
 team_id "7XS5GQGS29"

--- a/fastlane/actions/project_name.rb
+++ b/fastlane/actions/project_name.rb
@@ -12,7 +12,7 @@ module Fastlane
       # by the user and fails.
 
       def self.run(params)
-        default_project_name
+        params[:project_name]
       end
 
       # Fastlane Action class required functions.

--- a/fastlane/actions/project_name.rb
+++ b/fastlane/actions/project_name.rb
@@ -1,0 +1,71 @@
+require 'xcodeproj'
+
+module Fastlane
+  module Actions
+    class ProjectNameAction < Action
+
+      PROJECT_EXTENSION = ".xcodeproj".freeze
+
+      # This script returns the application name
+      # if there is a scheme that matches the project name.
+      # Otherwise, it assumes the project name should be specified 
+      # by the user and fails.
+
+      def self.run(params)
+        default_project_name
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: default_project_name)
+        ]
+      end
+
+      # Available options default_value helpers
+
+      # In case there is a single '.xcodeproj' in the default directory
+      # it can be automatically inferred by the script 
+      # if no parameter project is received.
+      def self.default_project
+        projects = Dir.entries('.').select { |each| File.extname(each) == PROJECT_EXTENSION }
+        if projects.length == 0
+          UI.abort_with_message! "No projects with extension %s found in root directory." % PROJECT_EXTENSION
+        end
+        if projects.length > 1
+          UI.abort_with_message! "Multiple projects with extension %s found in root directory." % PROJECT_EXTENSION
+        end
+        projects.first
+      end
+
+      # In case there is a scheme matching project's name
+      # it can be automatically inferred by the script 
+      # if no parameter scheme is received.
+      def self.matching_scheme
+        target = Xcodeproj::Project.open(default_project)
+          .targets
+          .find { |each| each.name == File.basename(default_project, File.extname(default_project)) }
+        if target.nil?
+          UI.abort_with_message! "No target matching project name %s found." % PROJECT_EXTENSION
+        end
+        target.name
+      end
+
+      # Just a wrapper for the matching scheme function.
+      def self.default_project_name
+        matching_scheme
+      end
+
+      # Name of the project file.
+      def self.default_project_filename
+        matching_scheme + PROJECT_EXTENSION
+      end
+
+    end
+  end
+end

--- a/fastlane/actions/read_project_property.rb
+++ b/fastlane/actions/read_project_property.rb
@@ -2,7 +2,7 @@ require 'xcodeproj'
 
 module Fastlane
   module Actions
-    class ReadProjectPropertyAction < Action
+    class ReadProjectPropertyAction < ProjectNameAction
 
       # Given a project, a scheme, and a build configuration
       # this script returns the corresponding value for the
@@ -23,28 +23,11 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project),
-          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_scheme),
+          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project_filename),
+          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_project_name),
           FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting, optional: false),
         ]
-      end
-
-      # Available options default_value helpers
-
-      # In case there is a single '.xcodeproj' in the default directory
-      # it can be automatically inferred by the script 
-      # if no parameter project is received.
-      def self.default_project
-        projects = Dir.entries('.').select { |each| each.end_with? '.xcodeproj' }
-        projects.length == 1 ? projects.first : nil
-      end
-
-      # In case there is a scheme matching project's name
-      # it can be automatically inferred by the script 
-      # if no parameter scheme is received.
-      def self.default_scheme
-        default_project.split('.').first
       end
 
     end

--- a/fastlane/actions/update_project_property.rb
+++ b/fastlane/actions/update_project_property.rb
@@ -2,7 +2,7 @@ require 'xcodeproj'
 
 module Fastlane
   module Actions
-    class UpdateProjectPropertyAction < Action
+    class UpdateProjectPropertyAction < ProjectNameAction
 
       # Given a project, a scheme, and a build configuration
       # this script updates the provided build setting
@@ -24,29 +24,12 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project),
-          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_scheme),
+          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project_filename),
+          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_project_name),
           FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting_value, optional: false),
         ]
-      end
-
-      # Available options default_value helpers
-
-      # In case there is a single '.xcodeproj' in the default directory
-      # it can be automatically inferred by the script 
-      # if no parameter project is received.
-      def self.default_project
-        projects = Dir.entries('.').select { |each| each.end_with? '.xcodeproj' }
-        projects.length == 1 ? projects.first : nil
-      end
-
-      # In case there is a scheme matching project's name
-      # it can be automatically inferred by the script 
-      # if no parameter scheme is received.
-      def self.default_scheme
-        default_project.split('.').first
       end
 
     end


### PR DESCRIPTION
Create a new action that infers the project name from the project, as long as there is a target that matches the project name.
This action allows to be provided a `project_name` in case the inferred name should not be used.
Taking advantage of this action, actions that inferred the project name by their own, now extend this new one, delegating this behavior.
Also, properties from `.env.default` have been moved to `Matchfile`, since they have to be there in case match is run from terminal. Otherwise, some properties are defaulted (for example `branch-name` to `master` and causing conflicts and unexpected changes).

The motivation for doing this is that we usually copy/paste the `fastlane` folder among projects, and sometimes we forget to change the `PROJECT_NAME` from `.env.default`, making a real mess everywhere. I don't want to have state belonging to the application inside the `fastlane` folder, and instead pick everything from the project.

@danielaRiesgo please take a look at the issues you added last week, and let me know if you have doubts. Most of them should be fixed now.

