### PR TITLE
[Fastlane] Remove rest-client gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,5 @@ gem 'carthage_cache'
 gem 'slather', '~>2.4.3'
 gem 'codestats-metrics-reporter'
 
-# Fastlane and fastlane related scripts gems
+# Fastlane
 gem 'fastlane', '~>2.62.0'
-gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nanaimo (0.2.3)
-    netrc (0.11.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     oga (1.3.1)
@@ -156,10 +155,6 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     retriable (3.1.1)
     rouge (2.0.7)
     ruby-ll (2.1.2)
@@ -212,7 +207,6 @@ DEPENDENCIES
   carthage_cache
   codestats-metrics-reporter
   fastlane (~> 2.62.0)
-  rest-client
   slather (~> 2.4.3)
 
 BUNDLED WITH

--- a/fastlane/actions/upload_dsym.rb
+++ b/fastlane/actions/upload_dsym.rb
@@ -15,8 +15,7 @@ module Fastlane
           -F access_token=#{params[:access_token]} \
           -F version=#{params[:version]} \
           -F bundle_identifier=#{params[:bundle_identifier]} \
-          -F dsym=@"#{params[:dsym_zip_path]}"
-        >
+          -F dsym=@"#{params[:dsym_zip_path]}">
 
         # If upload was successful "error" is 0.
         # https://rollbar.com/docs/api/items_post/

--- a/fastlane/actions/upload_dsym.rb
+++ b/fastlane/actions/upload_dsym.rb
@@ -19,9 +19,12 @@ module Fastlane
 
         # If upload was successful "error" is 0.
         # https://rollbar.com/docs/api/items_post/
-        not JSON.parse(response)["err"].zero?
+        error = !JSON.parse(response)["err"].zero?
+        if error
           UI.error("Error uploading DSYM file: #{JSON.parse(response)["message"]}")
+        end
 
+        error
       end
 
       # Fastlane Action class required functions.

--- a/fastlane/actions/upload_dsym.rb
+++ b/fastlane/actions/upload_dsym.rb
@@ -1,28 +1,28 @@
-require 'rest-client'
-
 module Fastlane
   module Actions
     class UploadDsymAction < Action
-      
-      # Given a dsym zip path, a Rollbar access token, 
+
+      # Given a dsym zip path, a Rollbar access token,
       # an app bundle identifier and an app version
-      # uploads the given dsym to Rollbar with 
+      # uploads the given dsym to Rollbar with
       # the provided configuration.
       # Returns if the upload was successful.
-      
+
       def self.run(params)
         # Uploads the zipped dsym file to Rollbar.
-        response = RestClient.post 'https://api.rollbar.com/api/1/dsym', { 
-          :access_token => params[:access_token],
-          :bundle_identifier => params[:bundle_identifier],
-          :version => params[:version],
-          :dsym => File.new(params[:dsym_zip_path]),
-          :multipart => true
-        }
 
-        # If upload was successful "error" is 0. 
+      response = %x<curl -X POST "https://api.rollbar.com/api/1/dsym" \
+          -F access_token=#{params[:access_token]} \
+          -F version=#{params[:version]} \
+          -F bundle_identifier=#{params[:bundle_identifier]} \
+          -F dsym=@"#{params[:dsym_zip_path]}"
+        >
+
+        # If upload was successful "error" is 0.
         # https://rollbar.com/docs/api/items_post/
-        JSON.parse(response)["err"].zero?
+        not JSON.parse(response)["err"].zero?
+          UI.error("Error uploading DSYM file: #{JSON.parse(response)["message"]}")
+
       end
 
       # Fastlane Action class required functions.


### PR DESCRIPTION
## Summary ##

Removes `rest-client` gem need from Fastlane's lanes, implementing DSYM upload with a bash call instead in `upload_dsym` action.