### PR TITLE
Bundle identifiers

### DIFF
--- a/BaseProject.xcodeproj/project.pbxproj
+++ b/BaseProject.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-D DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.debug;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProject.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -522,7 +522,7 @@
 				);
 				INFOPLIST_FILE = BaseProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseProject.app/BaseProject";
@@ -535,7 +535,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = BaseProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = BaseProject;
@@ -607,7 +607,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_SWIFT_FLAGS = "-D ALPHA";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject.alpha;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProject.alpha;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -627,7 +627,7 @@
 				);
 				INFOPLIST_FILE = BaseProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseProject.app/BaseProject";
@@ -640,7 +640,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = BaseProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = BaseProject;
@@ -711,7 +711,7 @@
 				INFOPLIST_FILE = BaseProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -731,7 +731,7 @@
 				);
 				INFOPLIST_FILE = BaseProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseProject.app/BaseProject";
@@ -744,7 +744,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = BaseProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = BaseProject;
@@ -814,7 +814,7 @@
 				INFOPLIST_FILE = BaseProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D PRODUCTION";
-				PRODUCT_BUNDLE_IDENTIFIER = com.baseproject.BaseProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.BaseProject.BaseProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -834,7 +834,7 @@
 				);
 				INFOPLIST_FILE = BaseProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BaseProject.app/BaseProject";
@@ -847,7 +847,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = BaseProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = ar.com.wolox.BaseProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Wolox.BaseProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = BaseProject;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,8 +36,24 @@ platform :ios do
   # Run this before doing anything else
   before_all do
 
-    desc "Simply validate the project name and main target are properly configured."
+    desc "Validate the project name and main target are properly configured."
     UI.message "Running lane for project: `%s`" % project_name
+
+    desc "Validate the configured bundle identifiers match the expected ones."
+    expected_bundle_identifiers = Hash[build_configurations.values.uniq.map { |each| [each, []] }]
+    build_configurations.each do |key, value|
+      expected_bundle_identifiers[value].push(infer_bundle_identifier(build_configuration: key))
+    end
+    expected_bundle_identifiers.each do |key, value|
+      found_bundle_identifier = read_project_property(
+        build_configuration: key, 
+        build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
+      )
+      UI.message "Validating bundle identifier for '#{key}'. Expected: '#{value}', found: '#{found_bundle_identifier}'."
+      unless value.include?(found_bundle_identifier)
+        UI.abort_with_message! "Aborting due to mismatching in bundle identifier for build configuration '#{value}'."
+      end
+    end
 
   end
 

--- a/fastlane/actions/infer_bundle_identifier.rb
+++ b/fastlane/actions/infer_bundle_identifier.rb
@@ -1,0 +1,51 @@
+module Fastlane
+  module Actions
+    class InferBundleIdentifierAction < Action
+
+      # Given a build configuration
+      # this script builds the corresponding bundle identifier
+      # that should be used.
+
+      # This is useful to validate the bundle identifiers chosen
+      # during the kickoff are correct.
+
+      # Format for bundle identifiers by build configuration.
+      BUNDLE_IDENTIFIERS_FORMAT = {
+        test: "com.%s.%s.debug",
+        qa: "com.%s.%s.alpha",
+        appstore: "com.%s.%s",
+        production: "com.%s.%s"
+      }.freeze
+
+      # If the application is deployed in Wolox account choose Wolox
+      # as owner, otherwise choose project name.
+      DEPLOYED_IN_WOLOX_ACCOUNT = {
+        test: true,
+        qa: true,
+        appstore: true,
+        production: false
+      }.freeze
+
+      def self.run(params)
+        # For legacy projects, just override the return value
+        # with the desired bundle identifier.
+        bundle_identifier_format = BUNDLE_IDENTIFIERS_FORMAT[params[:build_configuration]]
+        team_name = DEPLOYED_IN_WOLOX_ACCOUNT[params[:build_configuration]] ? "Wolox" : ProjectNameAction.default_project_name
+        bundle_identifier_format % [team_name, ProjectNameAction.default_project_name]
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+        ]
+      end
+
+    end
+  end
+end

--- a/fastlane/actions/project_name.rb
+++ b/fastlane/actions/project_name.rb
@@ -12,7 +12,7 @@ module Fastlane
       # by the user and fails.
 
       def self.run(params)
-        params[:project_name]
+        default_project_name
       end
 
       # Fastlane Action class required functions.
@@ -23,7 +23,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: default_project_name)
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: false)
         ]
       end
 

--- a/fastlane/actions/read_project_property.rb
+++ b/fastlane/actions/read_project_property.rb
@@ -2,17 +2,22 @@ require 'xcodeproj'
 
 module Fastlane
   module Actions
-    class ReadProjectPropertyAction < ProjectNameAction
+    class ReadProjectPropertyAction < Action
 
       # Given a project, a scheme, and a build configuration
       # this script returns the corresponding value for the
       # provided build setting.
 
       def self.run(params)
-        Xcodeproj::Project.open(params[:project])
+        build_configuration = Xcodeproj::Project.open(params[:project])
           .targets.find { |each| each.name == params[:scheme] }
           .build_configurations.find { |each| each.name == params[:build_configuration] }
-          .build_settings[params[:build_setting]]
+
+        if build_configuration.nil?
+          UI.abort_with_message! "Build configuration '#{params[:build_configuration]}' is not configured."
+        end
+
+        build_configuration.build_settings[params[:build_setting]]
       end
 
       # Fastlane Action class required functions.
@@ -23,8 +28,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project_filename),
-          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_project_name),
+          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: ProjectNameAction.default_project_filename),
+          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: ProjectNameAction.default_project_name),
           FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting, optional: false),
         ]

--- a/fastlane/actions/update_project_property.rb
+++ b/fastlane/actions/update_project_property.rb
@@ -2,7 +2,7 @@ require 'xcodeproj'
 
 module Fastlane
   module Actions
-    class UpdateProjectPropertyAction < ProjectNameAction
+    class UpdateProjectPropertyAction < Action
 
       # Given a project, a scheme, and a build configuration
       # this script updates the provided build setting
@@ -10,9 +10,15 @@ module Fastlane
 
       def self.run(params)
         project = Xcodeproj::Project.open(params[:project])
-        project.targets.find { |each| each.name == params[:scheme] }
+        build_configuration = project
+          .targets.find { |each| each.name == params[:scheme] }
           .build_configurations.find { |each| each.name == params[:build_configuration] }
-          .build_settings[params[:build_setting]] = params[:build_setting_value]
+
+        if build_configuration.nil?
+          UI.abort_with_message! "Build configuration '#{params[:build_configuration]}' is not configured."
+        end
+
+        build_configuration.build_settings[params[:build_setting]] = params[:build_setting_value]
         project.save
       end
 
@@ -24,8 +30,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: default_project_filename),
-          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: default_project_name),
+          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: ProjectNameAction.default_project_filename),
+          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: ProjectNameAction.default_project_name),
           FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting, optional: false),
           FastlaneCore::ConfigItem.new(key: :build_setting_value, optional: false),


### PR DESCRIPTION
## Summary ##

Created a new action `InferBundleIdentifierAction` which builds the `bundle id` a given `build configuration` should have. This is intended to validate the project is properly configured to avoid possible misconfigurations during kickoff. Also, this allows to move "custom project configurations" to actions, instead of having modifications in `Fastfile`.

Also, the optional parameter for `ProjectNameAction` was removed, instead, if a project should have a custom name, it has to be done in the action itself, instead of the `Fastfile`. Same as before.

Also, added validations in case a `build configuration` which does not exist needs to be accessed.
