### PR TITLE
Add swiftformat as a build phase

### DIFF
--- a/BaseProject.xcodeproj/project.pbxproj
+++ b/BaseProject.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 				9D1574FF1CB1B27500EA395E /* Resources */,
 				9D6E405D1CB1B93F008CE558 /* Carthage */,
 				9D6E405E1CB1B94C008CE558 /* SwiftLint */,
+				B8FCC88A21DFED8100E44ECB /* SwiftFormat */,
 			);
 			buildRules = (
 			);
@@ -388,6 +389,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ ! -z \"$RUNNING_ON_CI\" ]\nthen\n    echo \"SwiftLint run script has been disabled\"\n    exit 0\nfi\n\nif which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+		B8FCC88A21DFED8100E44ECB /* SwiftFormat */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftFormat;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftformat >/dev/null; then\nswiftformat .\nelse\necho \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/config.swiftformat
+++ b/config.swiftformat
@@ -1,0 +1,46 @@
+# blank lines & spaces
+--blankLinesAtEndOfScope false
+--blankLinesAtStartOfScope true
+--blankLinesBetweenScopes true
+--blankLinesAroundMark false
+--consecutiveBlankLines true
+
+# imports
+--duplicateImports true
+--sortedImports true
+
+# redundant things
+--redundantBackticks true
+--redundantLet true
+--redundantLetError true
+--redundantParens true
+--redundantPattern true
+--redundantReturn true
+--redundantSelf true
+--redundantVoidReturnType true
+--redundantInit true
+--semicolons never
+
+# spaces
+--spaceAroundBraces true
+--spaceAroundComments true
+--spaceAroundGenerics true
+--spaceAroundOperators true
+--spaceAroundParens true
+--spaceInsideBraces true
+--spaceInsideBrackets true
+--spaceInsideComments true
+--spaceInsideGenerics true
+--spaceInsideParens true
+--consecutiveSpaces true
+
+--elseOnSameLine true
+--emptyBraces true
+--indent tabs
+--linebreakAtEndOfFile true
+
+--specifiers true
+--strongOutlets true
+--todos true
+--unusedArguments true
+--andOperator true


### PR DESCRIPTION
Add [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) as a build phase and a standard configuration file to follow our guidelines.

You can check the rules we are using in `config.swiftformat` and check what they do (and other potential rules) [here](https://github.com/nicklockwood/SwiftFormat#rules).

⚠️ Do not merge this until we are sure that we want to use SwiftFormat in our future projects ⚠️ 

